### PR TITLE
Move over to new Azure SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Step 1 : Create a new general-purpose storage account to use for this tutorial.
  
 Step 2 : Copy and save keys.
  
- * After your storage account is created, click on it to open it. Select **Settings** > **Access keys** > **Primary Key**, copy the associated **Connection string** to the clipboard, then paste it into a text editor for later use.
+ * After your storage account is created, click on it to open it. Select **Settings** > **Access keys** > **Key1**, copy the associated **Connection string** to the clipboard, then paste it into a text editor for later use.
 
 ## Set up
 
@@ -91,7 +91,7 @@ Container "demo" is deleted
 Done
 ```
 
-# Folder introduction
+# Folder Introduction
 You will find the following folders: key-vault-node-quickstart-v3, which references the version 3.0 SDK and keyvault-node-quickstart-v4, which uses the 4.0 version of the SDK.
 * To use the latest Azure SDK version [azure-storage-js-v10-quickstart-v4] please add the following dependency:
   * [@azure/storage-blob](https://www.npmjs.com/package/@azure/storage-blob)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Container "demo" is deleted
 Done
 ```
 
-# Azure SDK versions
+# Folder introduction
 You will find the following folders: key-vault-node-quickstart-v3, which references the version 3.0 SDK and keyvault-node-quickstart-v4, which uses the 4.0 version of the SDK.
 * To use the latest Azure SDK version [azure-storage-js-v10-quickstart-v4] please add the following dependency:
   * [@azure/storage-blob](https://www.npmjs.com/package/@azure/storage-blob)

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Done
 
 # Azure SDK versions
 You will find the following folders: key-vault-node-quickstart-v3, which references the version 3.0 SDK and keyvault-node-quickstart-v4, which uses the 4.0 version of the SDK.
-* azure-storage-js-v10-quickstart-v3 referenced to following packages:
-  * [@azure/storage-blob v10.5.0](https://www.npmjs.com/package/@azure/storage-blob/v/10.5.0)
-* azure-storage-js-v10-quickstart-v4 referenced to following packages:
+* To use the latest Azure SDK version [azure-storage-js-v10-quickstart-v4] please add the following dependency:
   * [@azure/storage-blob](https://www.npmjs.com/package/@azure/storage-blob)
   * [@azure/abort-controller](https://www.npmjs.com/package/@azure/abort-controller)
+* For the previous stable Azure SDK version [azure-storage-js-v10-quickstart-v3] please add the following dependency:
+  * [@azure/storage-blob v10.5.0](https://www.npmjs.com/package/@azure/storage-blob/v/10.5.0)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Step 2 : Copy and save keys.
 ## Set up
 
 1.Clone
+
 Clone the repository on your machine:
 
 ```bash
@@ -43,6 +44,7 @@ git clone https://github.com/Azure-Samples/azure-storage-js-v10-quickstart.git
 ```
 
 2.Switch Folder
+
 Then, switch to the appropriate folder "azure-storage-js-v10-quickstart-v3" and "azure-storage-js-v10-quickstart-v4":
 
 ```bash
@@ -54,6 +56,7 @@ cd azure-storage-js-v10-quickstart-v4
 ```
 
 3.Install Dependencies
+
 Next, install the dependencies:
 
     npm install

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Step 1 : Create a new general-purpose storage account to use for this tutorial.
  
 Step 2 : Copy and save keys.
  
- * After your storage account is created, it is pinned to the dashboard. Click on it to open it. Under SETTINGS, click **Access keys**. Select a key and copy the **key1** to the clipboard, then paste it into text editor for later use.
+ * After your storage account is created, click on it to open it. Select **Settings** > **Access keys** > **Primary Key**, copy the associated **Connection string** to the clipboard, then paste it into a text editor for later use.
 
 ## Set up
 


### PR DESCRIPTION
Purpose
Move over this sample to new Azure SDK:

Move the original file to azure-storage-js-v10-quickstart-v3 folder

Add folder azure-storage-js-v10-quickstart-v4 for the sample referenced to the new SDK

Add the readme to introduce the Sample and folders in the root folder.

Add two sections to the readme:
- Prerequisites
- Folder Introduction

What old sample do:
![68571591-465c0100-049e-11ea-9f28-6c7e012d6b3a](https://user-images.githubusercontent.com/52488926/68742627-961c0300-062b-11ea-90a2-ab9d4b56c655.png)

What can be updated to V4:
![68571602-4eb43c00-049e-11ea-888f-d865ac8e4b69](https://user-images.githubusercontent.com/52488926/68742649-a6cc7900-062b-11ea-9b32-f0e78033a6ed.png)


What can't be updated against new SDK,our solution :
user already created a storage account, keep it